### PR TITLE
Add pool.end call on shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -1121,7 +1121,7 @@ client.on('message', async msg => {
 });
 
 // Add graceful shutdown handling
-process.on('SIGINT', () => {
+process.on('SIGINT', async () => {
     console.log('\n🛑 Received SIGINT, shutting down gracefully...');
     if (healthCheckInterval) {
         clearInterval(healthCheckInterval);
@@ -1129,16 +1129,28 @@ process.on('SIGINT', () => {
     if (client) {
         client.destroy();
     }
+    try {
+        await pool.end();
+        console.log('✅ Database pool closed');
+    } catch (err) {
+        console.error('❌ Error closing database pool:', err.message);
+    }
     process.exit(0);
 });
 
-process.on('SIGTERM', () => {
+process.on('SIGTERM', async () => {
     console.log('\n🛑 Received SIGTERM, shutting down gracefully...');
     if (healthCheckInterval) {
         clearInterval(healthCheckInterval);
     }
     if (client) {
         client.destroy();
+    }
+    try {
+        await pool.end();
+        console.log('✅ Database pool closed');
+    } catch (err) {
+        console.error('❌ Error closing database pool:', err.message);
     }
     process.exit(0);
 });


### PR DESCRIPTION
## Summary
- close PostgreSQL connection pool in SIGINT/SIGTERM handlers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866d368cec483228e7ed03ff0cabe1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown by ensuring the database connection is properly closed when the application stops.
  * Enhanced logging to confirm successful or failed database disconnection during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->