### PR TITLE
Fix database column reference in /chats command

### DIFF
--- a/index.js
+++ b/index.js
@@ -711,9 +711,9 @@ async function getRecentActiveChats() {
         SELECT DISTINCT cc.*, pm.last_activity 
         FROM chat_configs cc
         LEFT JOIN (
-            SELECT chat_id, MAX(created_at) as last_activity
+            SELECT chat_id, MAX(processed_at) as last_activity
             FROM processed_messages 
-            WHERE created_at > $1
+            WHERE processed_at > $1
             GROUP BY chat_id
         ) pm ON cc.chat_id = pm.chat_id
         WHERE pm.last_activity IS NOT NULL OR cc.is_monitored = true


### PR DESCRIPTION
## Summary
• Fixed column reference error in `/chats` command that was causing database query to fail
• Changed `created_at` to `processed_at` in `getRecentActiveChats()` function to match actual schema

## Test plan
- [x] Verify `/chats` command now works without throwing column errors
- [x] Confirm query returns expected results for recent active chats

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of recent active chats by using the latest processed message time instead of creation time to determine chat activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->