### PR TITLE
Fix processed message update logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -576,9 +576,10 @@ async function isMessageProcessed(messageId) {
 
 async function markMessageProcessed(messageId, chatId, hadTaskIndicators, wasAnalyzed) {
     await pool.query(
-        `INSERT INTO processed_messages (message_id, chat_id, had_task_indicators, was_analyzed) 
-         VALUES ($1, $2, $3, $4) 
-         ON CONFLICT (message_id) DO NOTHING`,
+        `INSERT INTO processed_messages (message_id, chat_id, had_task_indicators, was_analyzed)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (message_id)
+         DO UPDATE SET had_task_indicators = $3, was_analyzed = $4, processed_at = CURRENT_TIMESTAMP`,
         [messageId, chatId, hadTaskIndicators, wasAnalyzed]
     );
 }


### PR DESCRIPTION
## Summary
- update `markMessageProcessed` so conflicts update indicator flags and timestamp

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867916c448483228f886a3907f24d74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of processed messages to ensure their status and timestamp are always updated when re-processed, instead of being ignored if they already exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->