### PR TITLE
Fix event handlers in chat manager

### DIFF
--- a/public/chat-manager.html
+++ b/public/chat-manager.html
@@ -299,8 +299,8 @@
         
         <div class="content">
             <div class="nav-buttons">
-                <button class="nav-btn active" onclick="showAllChats()">All Chats</button>
-                <button class="nav-btn" onclick="showTasks()">Tasks</button>
+                <button class="nav-btn active" onclick="showAllChats(event)">All Chats</button>
+                <button class="nav-btn" onclick="showTasks(event)">Tasks</button>
             </div>
             
             <div id="success-message" class="success-message" style="display: none;"></div>
@@ -456,16 +456,16 @@
             }
         }
         
-        function showAllChats() {
+        function showAllChats(evt) {
             document.querySelectorAll('.nav-btn').forEach(btn => btn.classList.remove('active'));
-            event.target.classList.add('active');
+            evt.target.classList.add('active');
             document.getElementById('chat-section').style.display = 'block';
             document.getElementById('task-section').style.display = 'none';
         }
-        
-        function showTasks() {
+
+        function showTasks(evt) {
             document.querySelectorAll('.nav-btn').forEach(btn => btn.classList.remove('active'));
-            event.target.classList.add('active');
+            evt.target.classList.add('active');
             document.getElementById('chat-section').style.display = 'none';
             document.getElementById('task-section').style.display = 'block';
             renderTasks();


### PR DESCRIPTION
## Summary
- pass the click event into `showAllChats` and `showTasks`
- update the handlers to use the parameter instead of the global `event`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686794ee6dac83228732429d67dc85f5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved event handling for "All Chats" and "Tasks" buttons to enhance reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->