### PR TITLE
Fix active chat query

### DIFF
--- a/index.js
+++ b/index.js
@@ -708,12 +708,12 @@ async function getAllChats() {
 async function getRecentActiveChats() {
     const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const result = await pool.query(`
-        SELECT DISTINCT cc.*, pm.last_activity 
+        SELECT DISTINCT cc.*, pm.last_activity
         FROM chat_configs cc
         LEFT JOIN (
-            SELECT chat_id, MAX(created_at) as last_activity
-            FROM processed_messages 
-            WHERE created_at > $1
+            SELECT chat_id, MAX(processed_at) as last_activity
+            FROM processed_messages
+            WHERE processed_at > $1
             GROUP BY chat_id
         ) pm ON cc.chat_id = pm.chat_id
         WHERE pm.last_activity IS NOT NULL OR cc.is_monitored = true


### PR DESCRIPTION
## Summary
- fix SQL join in `getRecentActiveChats` to use `processed_at`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa136ef148322b4cf218f14229b3d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of recent chat activity by using the processed time of messages instead of their creation time when displaying recent active chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->