### PR TITLE
Add MAX_MESSAGE_HISTORY_DAYS variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ OPENAI_API_KEY=your_openai_api_key_here
 MONITORED_CHATS=Test Group,Family Chat,Work Group
 BOT_COMMAND_CHAT=Bot Commands
 
+# Number of days of message history to read for /read_unread
+MAX_MESSAGE_HISTORY_DAYS=3
+
 # PostgreSQL Database Configuration
 DB_HOST=localhost
 DB_PORT=5432

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ OPENAI_API_KEY=your_openai_api_key_here
 # WhatsApp Configuration
 MONITORED_CHATS=Work Team,Family Chat,Project Group
 BOT_COMMAND_CHAT=Bot Commands
+MAX_MESSAGE_HISTORY_DAYS=3
 
 # PostgreSQL Database Configuration
 DB_HOST=localhost
@@ -83,6 +84,8 @@ DB_PASSWORD=your_postgres_password_here
 # Dashboard Configuration
 DASHBOARD_PORT=3000
 ```
+
+`MAX_MESSAGE_HISTORY_DAYS` controls how many days of messages the bot looks back when running the `/read_unread` command.
 
 ### Required API Keys
 


### PR DESCRIPTION
## Summary
- include message history retention in `.env.example`
- show MAX_MESSAGE_HISTORY_DAYS variable in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b413e3c6c83228766f6d396282fb4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new environment variable, `MAX_MESSAGE_HISTORY_DAYS`, to the configuration documentation with a default value and explanation of its purpose for message history retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->