### PR TITLE
Update README with history commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,13 @@ DB_PASSWORD=your_postgres_password_here
 
 # Dashboard Configuration
 DASHBOARD_PORT=3000
+
+# Message History
+MAX_MESSAGE_HISTORY_DAYS=3
 ```
+
+`MAX_MESSAGE_HISTORY_DAYS` controls how many days of messages are
+considered when using `/read_unread`. The default is `3` days.
 
 ### Required API Keys
 
@@ -113,6 +119,11 @@ Use these commands in your designated "Bot Commands" chat:
 - `/monitor <number>` - Start monitoring a chat
 - `/unmonitor <number>` - Stop monitoring a chat
 - `/refresh` - Refresh chat discovery
+
+**Message History:**
+- `/read_unread [days]` - List unread messages from the last N days (default history window)
+- `/mark_read` - Mark all messages as read and update the timestamp
+- `/status` - Show bot login info and monitoring status
 
 **Dashboard & Help:**
 - `/dashboard` - Get secure mobile dashboard link


### PR DESCRIPTION
## Summary
- document `/read_unread`, `/mark_read`, and `/status` commands
- mention `MAX_MESSAGE_HISTORY_DAYS` configuration

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b41583b9083228373f504cb7e7e1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README to include a new environment variable for message history settings.
  * Added explanations for message history management commands, including `/read_unread`, `/mark_read`, and `/status`.
  * Organized bot commands into a new "Message History" category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->