### PR TITLE
Cleanup duplicate getMonitoredChats

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -51,9 +51,9 @@ function cleanupExpiredTokens() {
 function getLocalIPAddress() {
     const interfaces = os.networkInterfaces();
     for (const name of Object.keys(interfaces)) {
-        for (const interface of interfaces[name]) {
-            if (interface.family === 'IPv4' && !interface.internal) {
-                return interface.address;
+        for (const iface of interfaces[name]) {
+            if (iface.family === 'IPv4' && !iface.internal) {
+                return iface.address;
             }
         }
     }

--- a/index.js
+++ b/index.js
@@ -696,12 +696,6 @@ async function saveChatConfig(chatInfo) {
     `, [chatInfo.id, chatInfo.name, isCurrentlyMonitored, chatInfo.isGroup, chatInfo.participantCount]);
 }
 
-async function getMonitoredChats() {
-    const result = await pool.query(
-        'SELECT chat_id, chat_name FROM chat_configs WHERE is_monitored = true ORDER BY chat_name'
-    );
-    return result.rows;
-}
 
 async function getAllChats() {
     const result = await pool.query(


### PR DESCRIPTION
## Summary
- remove the first `getMonitoredChats` definition
- adjust dashboard code to avoid `interface` keyword

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b415ace308322bdf1ae58ba3986a6