### PR TITLE
Improve message fetch loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ DB_PASSWORD=your_postgres_password_here
 
 # Dashboard Configuration
 DASHBOARD_PORT=3000
+
+# Message Retrieval
+MESSAGE_FETCH_LIMIT=50

--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ DB_PASSWORD=your_postgres_password_here
 
 # Dashboard Configuration
 DASHBOARD_PORT=3000
+# Message Retrieval
+MESSAGE_FETCH_LIMIT=50
 ```
+
+`MESSAGE_FETCH_LIMIT` sets how many messages to request at a time when scanning chats for unread history. Increase it to search further back.
 
 ### Required API Keys
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 let MONITORED_CHATS = process.env.MONITORED_CHATS?.split(',') || ['Test Group'];
 const BOT_COMMAND_CHAT = process.env.BOT_COMMAND_CHAT || 'Bot Commands';
 const MAX_MESSAGE_HISTORY_DAYS = parseInt(process.env.MAX_MESSAGE_HISTORY_DAYS) || 3;
+const MESSAGE_FETCH_LIMIT = parseInt(process.env.MESSAGE_FETCH_LIMIT) || 50;
 
 // Store discovered chats for management
 let discoveredChats = new Map();
@@ -1579,7 +1580,7 @@ async function getMonitoredChats() {
     }
 }
 
-async function getMessagesFromChat(chatId, fromTimestamp, maxDays = null) {
+async function getMessagesFromChat(chatId, fromTimestamp, maxDays = null, fetchLimit = MESSAGE_FETCH_LIMIT) {
     try {
         const chat = await client.getChatById(chatId);
         if (!chat) {
@@ -1596,15 +1597,25 @@ async function getMessagesFromChat(chatId, fromTimestamp, maxDays = null) {
             }
         }
         
-        // Fetch messages with a reasonable limit
-        const messages = await chat.fetchMessages({ limit: 50 });
-        
-        // Filter messages by timestamp
-        const filteredMessages = messages.filter(msg => {
+        // Loop fetching messages until we encounter one older than earliestTimestamp
+        let limit = fetchLimit;
+        let messages = await chat.fetchMessages({ limit });
+        let filteredMessages = messages.filter(msg => {
             const messageDate = new Date(msg.timestamp * 1000);
             return messageDate >= earliestTimestamp;
         });
-        
+
+        // Increase limit and refetch while all messages are within the time window
+        // and more messages may be available
+        while (filteredMessages.length === messages.length && messages.length === limit) {
+            limit += fetchLimit;
+            messages = await chat.fetchMessages({ limit });
+            filteredMessages = messages.filter(msg => {
+                const messageDate = new Date(msg.timestamp * 1000);
+                return messageDate >= earliestTimestamp;
+            });
+        }
+
         // Format messages for display
         return filteredMessages.map(msg => ({
             id: msg.id._serialized,
@@ -1646,7 +1657,7 @@ async function getUnreadMessages(maxDays = null) {
         
         for (const chatConfig of monitoredChats) {
             console.log(`   📱 Checking ${chatConfig.chat_name}...`);
-            const messages = await getMessagesFromChat(chatConfig.chat_id, lastReadTimestamp, maxDays);
+            const messages = await getMessagesFromChat(chatConfig.chat_id, lastReadTimestamp, maxDays, MESSAGE_FETCH_LIMIT);
             
             if (messages.length > 0) {
                 console.log(`   ✅ Found ${messages.length} messages in ${chatConfig.chat_name}`);


### PR DESCRIPTION
## Summary
- allow configuring how many messages to fetch via `MESSAGE_FETCH_LIMIT`
- keep fetching until an older message than the target timestamp is found
- document new environment option

## Testing
- `npm install` *(fails: Failed to set up Chromium)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b416c12f483228a0cc9392f13418f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting to control how many messages are fetched at a time when scanning chats for unread history.

* **Documentation**
  * Updated the README to explain the new message fetch limit configuration and its usage.

* **Refactor**
  * Improved message retrieval logic to fetch messages in batches based on the configurable limit, ensuring all relevant messages are retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->